### PR TITLE
KCGML-2668 kcg-data-scraper-csharp: Move the "Start server" and server wrapper to kcg-xlib repo

### DIFF
--- a/KcgXLib.sln
+++ b/KcgXLib.sln
@@ -27,6 +27,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "lib-minio", "lib-minio\lib-
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "lib-http", "lib-http\lib-http.csproj", "{33DD780A-68AD-4DD2-BF9F-DE63D8B4A7AF}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "lib-http-server", "lib-http-server\lib-http-server.csproj", "{AE13C0A7-737D-44C3-8068-637976FCD2FE}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -81,6 +83,10 @@ Global
 		{33DD780A-68AD-4DD2-BF9F-DE63D8B4A7AF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{33DD780A-68AD-4DD2-BF9F-DE63D8B4A7AF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{33DD780A-68AD-4DD2-BF9F-DE63D8B4A7AF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AE13C0A7-737D-44C3-8068-637976FCD2FE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AE13C0A7-737D-44C3-8068-637976FCD2FE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AE13C0A7-737D-44C3-8068-637976FCD2FE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AE13C0A7-737D-44C3-8068-637976FCD2FE}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/lib-http-server/HttpServer.cs
+++ b/lib-http-server/HttpServer.cs
@@ -12,7 +12,7 @@ namespace HttpServer;
 public class HttpServer
 {
     private readonly WebApplicationBuilder _builder;
-    private WebApplication _app = null!;
+    public WebApplication app = null!;
     private IConfigurationRoot _appSettings = null!;
     private int _connectionCounter = 0;  
 
@@ -23,9 +23,9 @@ public class HttpServer
 
     public void BuildServer()
     {
-        if (_app == null)
+        if (app == null)
         {
-            _app = _builder.Build();
+            app = _builder.Build();
             DefaultAppSetup();
         }
     }
@@ -90,26 +90,26 @@ public class HttpServer
 
     public void AddEndPoint(HttpMethod httpMethod, string route, Delegate handler)
     {
-        if (_app == null)
+        if (app == null)
         {
             return;
         }
 
         if (httpMethod == HttpMethod.Get)
         {
-            _app.MapGet(route, handler);
+            app.MapGet(route, handler);
         }
         else if (httpMethod == HttpMethod.Post)
         {
-            _app.MapPost(route, handler);
+            app.MapPost(route, handler);
         }
         else if (httpMethod == HttpMethod.Put)
         {
-            _app.MapPut(route, handler);
+            app.MapPut(route, handler);
         }
         else if (httpMethod == HttpMethod.Delete)
         {
-            _app.MapDelete(route, handler);
+            app.MapDelete(route, handler);
         }
         else
         {
@@ -142,9 +142,9 @@ public class HttpServer
     public void DefaultAppSetup()
     {
         // Enable CORS
-        _app.UseCors("AllowSpecificOrigin");
-        _app.UseSwagger();
-        _app.UseSwaggerUI(options =>
+        app.UseCors("AllowSpecificOrigin");
+        app.UseSwagger();
+        app.UseSwaggerUI(options =>
         {
             options.SwaggerEndpoint("/swagger/v1/swagger.json", "v1");
             options.RoutePrefix = "docs";
@@ -154,7 +154,7 @@ public class HttpServer
 
         int ConnectionCounter = 0;  // Variable to track active number of connections
 
-        _app.Use(async (context, next) =>
+        app.Use(async (context, next) =>
         {
             int maxConnections = 1000; // Example limit. hardcoded for testing..this can be read from a settings file
             int currentConnections = Interlocked.Increment(ref ConnectionCounter); // Increment when a request starts
@@ -176,12 +176,12 @@ public class HttpServer
                 Interlocked.Decrement(ref ConnectionCounter);
             }
         });
-        _app.UseRouting();
+        app.UseRouting();
     }
 
     public void UseMiddleWare<TMiddleware>() where TMiddleware : class
     {
-        _app.UseMiddleware<TMiddleware>();
+        app.UseMiddleware<TMiddleware>();
     }
 
 }

--- a/lib-http-server/HttpServer.cs
+++ b/lib-http-server/HttpServer.cs
@@ -132,6 +132,10 @@ public class HttpServer
         app.MapDelete(route, handler);
     }
 
+    /*
+    Configures and adds CORS (Cross-Origin Resource Sharing) services to the application.
+    Allows requests only from the specified Web UI URL defined in the application settings.
+    */
     private void AddCORSService()
     {
         if (_appSettings == null)

--- a/lib-http-server/HttpServer.cs
+++ b/lib-http-server/HttpServer.cs
@@ -9,17 +9,17 @@ using System.Reflection;
 
 namespace HttpServer;
 
-public struct HttpServerSetup
+public class HttpServerConfiguration
 {
-    public string[] args;
-    public IConfigurationRoot appSettings;
-    public string swaggerName;
-    public string swaggerVersion;
-    public string swaggerTitle;
-    public string swaggerDescription;
-    public Type[] scopedServices;
-    public int maxConnections;
-    public Type[] middlewares;
+    public required string[] args;
+    public required IConfigurationRoot appSettings;
+    public required string swaggerName;
+    public required string swaggerVersion;
+    public required string swaggerTitle;
+    public required string swaggerDescription;
+    public required Type[] scopedServices;
+    public required int maxConnections;
+    public required Type[] middlewares;
 
 }
 
@@ -30,25 +30,25 @@ public class HttpServer
     private IConfigurationRoot _appSettings;
     private int _connectionCounter = 0;  
 
-    public HttpServer(HttpServerSetup serverSetup)
+    public HttpServer(HttpServerConfiguration serverConfig)
     {
-        _builder = WebApplication.CreateBuilder(serverSetup.args);
-        SetConfig(serverSetup.appSettings);
+        _builder = WebApplication.CreateBuilder(serverConfig.args);
+        SetConfig(serverConfig.appSettings);
         SetLogging();
-        SetSwaggerGen(serverSetup.swaggerName,
-                      serverSetup.swaggerVersion,
-                      serverSetup.swaggerTitle,
-                      serverSetup.swaggerDescription);
+        SetSwaggerGen(serverConfig.swaggerName,
+                      serverConfig.swaggerVersion,
+                      serverConfig.swaggerTitle,
+                      serverConfig.swaggerDescription);
 
-        foreach (var service in serverSetup.scopedServices)
+        foreach (var service in serverConfig.scopedServices)
         {
             AddScopedService(service);
         }
 
         AddCORSService();
-        BuildServer(serverSetup.maxConnections);
+        BuildServer(serverConfig.maxConnections);
 
-        foreach (var middleware in serverSetup.middlewares)
+        foreach (var middleware in serverConfig.middlewares)
         {
             UseMiddleware(middleware);
         }

--- a/lib-http-server/HttpServer.cs
+++ b/lib-http-server/HttpServer.cs
@@ -112,33 +112,24 @@ public class HttpServer
         method.Invoke(null, new object[] { _builder.Services });
     }
 
-    public void AddEndPoint(HttpMethod httpMethod, string route, Delegate handler)
+    public void AddGetEndPoint(string route, Delegate handler)
     {
-        if (app == null)
-        {
-            return;
-        }
-
-        if (httpMethod == HttpMethod.Get)
-        {
-            app.MapGet(route, handler);
-        }
-        else if (httpMethod == HttpMethod.Post)
-        {
-            app.MapPost(route, handler);
-        }
-        else if (httpMethod == HttpMethod.Put)
-        {
-            app.MapPut(route, handler);
-        }
-        else if (httpMethod == HttpMethod.Delete)
-        {
-            app.MapDelete(route, handler);
-        }
-        else
-        {
-            throw new NotSupportedException($"HTTP method {httpMethod} is not supported.");
-        }
+        app.MapGet(route, handler);
+    }
+    
+    public void AddPostEndPoint(string route, Delegate handler)
+    {
+        app.MapPost(route, handler);
+    }
+    
+    public void AddPutEndPoint(string route, Delegate handler)
+    {
+        app.MapPut(route, handler);
+    }
+    
+    public void AddDeleteEndPoint(string route, Delegate handler)
+    {
+        app.MapDelete(route, handler);
     }
 
     private void AddCORSService()
@@ -147,7 +138,7 @@ public class HttpServer
         {
             return;
         }
-
+        
         // Add CORS services
         string webUiUrl = _appSettings.GetSection("WebUI:Url").Value;
 

--- a/lib-http-server/HttpServer.cs
+++ b/lib-http-server/HttpServer.cs
@@ -1,0 +1,187 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.AspNetCore.Http;
+using Microsoft.OpenApi.Models;
+using System.Reflection;
+
+
+namespace HttpServer;
+
+public class HttpServer
+{
+    private readonly WebApplicationBuilder _builder;
+    private WebApplication _app = null!;
+    private IConfigurationRoot _appSettings = null!;
+    private int _connectionCounter = 0;  
+
+    public HttpServer(string[] args)
+    {
+        _builder = WebApplication.CreateBuilder(args);
+    }
+
+    public void BuildServer()
+    {
+        if (_app == null)
+        {
+            _app = _builder.Build();
+            DefaultAppSetup();
+        }
+    }
+
+    public void SetConfig(string configBasePath, string configFileName)
+    {
+        string env = _builder.Environment.EnvironmentName;
+
+        if (_appSettings == null)
+        {
+            IConfigurationRoot _appSettings = new ConfigurationBuilder()
+                .SetBasePath(configBasePath)
+                .AddJsonFile($"{configFileName}.json", optional: false, reloadOnChange: false)
+                .AddJsonFile($"{configFileName}.{env}.json", optional: true, reloadOnChange: false)
+                .Build();
+
+            _builder.Services.AddSingleton<IConfiguration>(_appSettings);
+            _builder.Logging.ClearProviders();
+            _builder.Logging.AddConfiguration(_appSettings.GetSection("Logging"));
+            _builder.Logging.AddConsole();
+        }
+    }
+    public void SetConfig(IConfigurationRoot appSettings)
+    {
+        _builder.Services.AddSingleton<IConfiguration>(appSettings);
+        
+        _builder.Logging.ClearProviders();
+        _builder.Logging.AddConfiguration(appSettings.GetSection("Logging"));
+        _builder.Logging.AddConsole();
+    }
+
+    public void SetSwaggerGen(string name, string version, string title, string description)
+    { 
+        _builder.Services.AddHttpContextAccessor(); // Register IHttpContextAccessor
+        // Add services to the container.
+        // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
+        _builder.Services.AddEndpointsApiExplorer();
+        // Add services to the container.
+        // Add Authorization Services
+        _builder.Services.AddAuthorization();
+        _builder.Services.AddSwaggerGen(options =>
+        {
+            options.EnableAnnotations();
+            options.SwaggerDoc(name: name, new OpenApiInfo
+            {
+                Version = version,
+                Title = title,
+                Description = description
+            });
+
+            var xmlFilename = $"{Assembly.GetExecutingAssembly().GetName().Name}.xml";
+            options.IncludeXmlComments(Path.Combine(AppContext.BaseDirectory, xmlFilename));
+            options.CustomSchemaIds(type => type.ToString());
+        });
+
+    }
+
+    public void AddScopedService<TService>() where TService : class
+    {
+        _builder.Services.AddScoped<TService>();
+    }
+
+    public void AddEndPoint(HttpMethod httpMethod, string route, Delegate handler)
+    {
+        if (_app == null)
+        {
+            return;
+        }
+
+        if (httpMethod == HttpMethod.Get)
+        {
+            _app.MapGet(route, handler);
+        }
+        else if (httpMethod == HttpMethod.Post)
+        {
+            _app.MapPost(route, handler);
+        }
+        else if (httpMethod == HttpMethod.Put)
+        {
+            _app.MapPut(route, handler);
+        }
+        else if (httpMethod == HttpMethod.Delete)
+        {
+            _app.MapDelete(route, handler);
+        }
+        else
+        {
+            throw new NotSupportedException($"HTTP method {httpMethod} is not supported.");
+        }
+    }
+
+    public void AddCORSService()
+    {
+        if (_appSettings == null)
+        {
+            return;
+        }
+
+        // Add CORS services
+        string webUiUrl = _appSettings.GetSection("WebUI:Url").Value;
+
+        _builder.Services.AddCors(options =>
+        {
+            options.AddPolicy("AllowSpecificOrigin",
+            builder =>
+            {
+                builder.WithOrigins(webUiUrl)
+                   .AllowAnyMethod()
+                   .AllowAnyHeader();
+            });
+        });
+    }
+
+    public void DefaultAppSetup()
+    {
+        // Enable CORS
+        _app.UseCors("AllowSpecificOrigin");
+        _app.UseSwagger();
+        _app.UseSwaggerUI(options =>
+        {
+            options.SwaggerEndpoint("/swagger/v1/swagger.json", "v1");
+            options.RoutePrefix = "docs";
+        });
+
+        // Middleware to track current number of connections
+
+        int ConnectionCounter = 0;  // Variable to track active number of connections
+
+        _app.Use(async (context, next) =>
+        {
+            int maxConnections = 1000; // Example limit. hardcoded for testing..this can be read from a settings file
+            int currentConnections = Interlocked.Increment(ref ConnectionCounter); // Increment when a request starts
+
+            if (currentConnections > maxConnections)
+            {
+                Interlocked.Decrement(ref ConnectionCounter); // Decrement when a request ends
+                context.Response.StatusCode = 429; // Too Many Requests
+                await context.Response.WriteAsync("Server busy. Try again later.");
+                return;
+            }
+
+            try
+            {
+                await next.Invoke();
+            }
+            finally
+            {
+                Interlocked.Decrement(ref ConnectionCounter);
+            }
+        });
+        _app.UseRouting();
+    }
+
+    public void UseMiddleWare<TMiddleware>() where TMiddleware : class
+    {
+        _app.UseMiddleware<TMiddleware>();
+    }
+
+}

--- a/lib-http-server/README.md
+++ b/lib-http-server/README.md
@@ -1,0 +1,3 @@
+# lib-http-server Library README
+
+The `lib-http-server` is a library designed to facilitate the creation of a http server and API endpoint registering.

--- a/lib-http-server/lib-http-server.csproj
+++ b/lib-http-server/lib-http-server.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <RootNamespace>lib_http_server</RootNamespace>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.20" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.5.0" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
[KCGML-2668](https://kcg.youtrack.cloud/issue/KCGML-2668) kcg-data-scraper-csharp: Move the "Start server" and server wrapper to kcg-xlib repo

I replicated what was done in the OrchestrationProgram.cs (from scraper repo) in the HttpServer.cs in a more generic way. This should enable us to start the server using a setup struct.

Anything that is missing or not according to requirements, please let me know so I can make the adjustmetns.