### PR TITLE
Add LogRaw method for raw message logging

### DIFF
--- a/lib-log/libLog/LibLog.cs
+++ b/lib-log/libLog/LibLog.cs
@@ -150,6 +150,11 @@ namespace LogUtility
             WriteLog(msg + " " + timeString, ProfileColor);
         }
 
+        public static void LogRaw(string message)
+        {
+            WriteLog(message, DebugColor);
+        }
+        
         #region auto
         public static void LogDebug(string message, 
             [CallerMemberName] string callerName = "", 


### PR DESCRIPTION
Introduced a new LogRaw method to allow logging messages without additional formatting. This uses DebugColor for consistency with debug-level logs.