### PR TITLE
Set OutputPath to "build/" and streamline project configuration

### DIFF
--- a/lib-assert/lib-assert.csproj
+++ b/lib-assert/lib-assert.csproj
@@ -4,6 +4,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>disable</Nullable>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+        <OutputPath>build/</OutputPath>
     </PropertyGroup>
     <ItemGroup>
       <ProjectReference Include="..\lib-log\lib-log.csproj" />

--- a/lib-compression/lib-compression.csproj
+++ b/lib-compression/lib-compression.csproj
@@ -5,6 +5,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>disable</Nullable>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+        <OutputPath>build/</OutputPath>
     </PropertyGroup>
 
 </Project>

--- a/lib-hash/lib-hash.csproj
+++ b/lib-hash/lib-hash.csproj
@@ -7,6 +7,7 @@
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <LangVersion>preview</LangVersion>
         <DefineConstants>BLAKE_PUBLIC</DefineConstants>
+        <OutputPath>build/</OutputPath>
     </PropertyGroup>
 
 </Project>

--- a/lib-io/lib-io.csproj
+++ b/lib-io/lib-io.csproj
@@ -5,6 +5,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>disable</Nullable>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+        <OutputPath>build/</OutputPath>
     </PropertyGroup>
 
     <ItemGroup>

--- a/lib-io/libIO/PathUtils.cs
+++ b/lib-io/libIO/PathUtils.cs
@@ -146,6 +146,14 @@ public static class PathUtils
         return Path.Combine(path1, path2).Replace('\\', '/');
     }
 
+    public static string GetFileExtension(string path)
+    {
+        ValidatePath(path);
+        
+        string extension = Path.GetExtension(path);
+
+        return extension;
+    }
     public static string Join(string path1, string path2)
     {
         ValidatePath(path1);

--- a/lib-json/lib-json.csproj
+++ b/lib-json/lib-json.csproj
@@ -6,5 +6,6 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>disable</Nullable>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+        <OutputPath>build/</OutputPath>
     </PropertyGroup>
 </Project>

--- a/lib-log/lib-log.csproj
+++ b/lib-log/lib-log.csproj
@@ -5,5 +5,6 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>disable</Nullable>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+        <OutputPath>build/</OutputPath>
     </PropertyGroup>
 </Project>

--- a/lib-os/lib-os.csproj
+++ b/lib-os/lib-os.csproj
@@ -4,6 +4,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>disable</Nullable>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+        <OutputPath>build/</OutputPath>
     </PropertyGroup>
 
 </Project>

--- a/lib-time/lib-time.csproj
+++ b/lib-time/lib-time.csproj
@@ -5,6 +5,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>disable</Nullable>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+        <OutputPath>build/</OutputPath>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
### Description

- Updated all `.csproj` files to set the `OutputPath` property to the `build/` directory, ensuring consistent build artifact locations across all projects.
- Organized test project outputs by specifying a custom directory under the `build/` folder.
- Commented out unused pipeline queue additions in `CodeHelperTaskExecution.cs` to simplify execution logic. 

This standardizes project configurations and improves overall project structure. 
