### PR TITLE
Add GitUtils to handle non-ignored files and remove unused project

### DIFF
--- a/lib-io/libIO/GitUtils.cs
+++ b/lib-io/libIO/GitUtils.cs
@@ -1,9 +1,11 @@
 
 using FileLib;
+using UtilityIO;
 namespace libIO;
 
 public class GitUtils
 {
+    public const string GitIgnoreFileName = ".gitignore";
     static HashSet<string> GetIgnoredFiles(string gitIgnorePath, string rootPath)
     {
         HashSet<string> ignoredFiles = new HashSet<string>();
@@ -13,6 +15,7 @@ public class GitUtils
             return ignoredFiles;
         }
         
+        // Read all lines from the .gitignore file ignoring comments
         string[] ignorePatterns = File.ReadAllLines(gitIgnorePath)
                 .Where(line => !string.IsNullOrWhiteSpace(line) && !line.StartsWith("#"))
                 .ToArray();
@@ -20,6 +23,7 @@ public class GitUtils
         foreach (string pattern in ignorePatterns)
         {
             string fullPath = Path.Combine(rootPath, pattern.Trim());
+            
             if (Directory.Exists(fullPath))
             {
                 string[] files = Directory.GetFiles(fullPath, "*", SearchOption.AllDirectories);
@@ -35,5 +39,19 @@ public class GitUtils
         }
 
         return ignoredFiles;
+    }
+    
+    public static List<string> GetNonIgnoredFiles(string rootPath, string searchPattern)
+    {
+        string gitIgnorePath = PathUtils.Combine(rootPath, GitIgnoreFileName);
+        
+        HashSet<string> ignoredFiles = GetIgnoredFiles(gitIgnorePath, rootPath);
+        
+        List<string> files = Directory.GetFiles(rootPath, searchPattern, SearchOption.AllDirectories)
+            .Select(Path.GetFullPath)
+            .Where(file => !ignoredFiles.Contains(file))
+            .ToList();
+
+        return files;
     }
 }

--- a/lib-io/libIO/GitUtils.cs
+++ b/lib-io/libIO/GitUtils.cs
@@ -1,0 +1,39 @@
+
+using FileLib;
+namespace libIO;
+
+public class GitUtils
+{
+    static HashSet<string> GetIgnoredFiles(string gitIgnorePath, string rootPath)
+    {
+        HashSet<string> ignoredFiles = new HashSet<string>();
+
+        if (!FileUtils.FileExists(gitIgnorePath))
+        {
+            return ignoredFiles;
+        }
+        
+        string[] ignorePatterns = File.ReadAllLines(gitIgnorePath)
+                .Where(line => !string.IsNullOrWhiteSpace(line) && !line.StartsWith("#"))
+                .ToArray();
+
+        foreach (string pattern in ignorePatterns)
+        {
+            string fullPath = Path.Combine(rootPath, pattern.Trim());
+            if (Directory.Exists(fullPath))
+            {
+                string[] files = Directory.GetFiles(fullPath, "*", SearchOption.AllDirectories);
+                foreach (string file in files)
+                {
+                    ignoredFiles.Add(Path.GetFullPath(file));
+                }
+            }
+            else
+            {
+                ignoredFiles.Add(Path.GetFullPath(fullPath));
+            }
+        }
+
+        return ignoredFiles;
+    }
+}


### PR DESCRIPTION
### Description

This pull request introduces the following changes:
- Added a new `GitUtils` class within `libIO` to retrieve non-ignored files based on `.gitignore` rules. It includes the `GetNonIgnoredFiles` method and a constant for the `.gitignore` filename.
- Removed the `llm-project-insight` project from the solution as it is no longer needed.