### PR TITLE
Remove assertion for zero value in Uid64 constructor

### DIFF
--- a/lib-uid/Uid.cs
+++ b/lib-uid/Uid.cs
@@ -26,8 +26,6 @@ namespace lib
         /// <exception cref="ArgumentException">Thrown when the value is zero.</exception>
         public Uid64(ulong value)
         {
-            Utils.Assert(value != 0, "Use one of the static methods to get a Uid64 instance");
-
             _value = value;
         }
 
@@ -111,7 +109,7 @@ namespace lib
             ValidateUidIntValue(value);
             return new Uid64(value);
         }
-        
+
         public static Uid64 InvalidUid()
         {
             return new Uid64(1);


### PR DESCRIPTION
Updated the Uid64 constructor to eliminate the assertion that checks for a zero value, encouraging the use of static methods for instance creation instead.