### PR TITLE
Add logging for JSON deserialization errors

### DIFF
--- a/lib-json/lib-json.csproj
+++ b/lib-json/lib-json.csproj
@@ -8,4 +8,8 @@
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <OutputPath>build/</OutputPath>
     </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\lib-log\lib-log.csproj" />
+    </ItemGroup>
 </Project>

--- a/lib-json/libJson/Json.cs
+++ b/lib-json/libJson/Json.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using LogUtility;
 
 namespace libJson
 {
@@ -58,7 +59,8 @@ namespace libJson
             }
             catch (JsonException ex)
             {
-                throw new InvalidOperationException("Deserialization failed.", ex);
+                LibLog.LogDebug($"error deserializing: {ex}");
+                return default(T);
             }
         }
         


### PR DESCRIPTION
### Description

- Introduced debug logging for deserialization errors in the `Json` class.
- Integrated `lib-log` as a project reference.
- Ensures failures are logged for better error visibility while returning a default value instead of throwing exceptions.