### PR TITLE
Fix GetFilePath returning incorrect path in Windows after build.props change

### DIFF
--- a/lib-io/libIO/PathUtils.cs
+++ b/lib-io/libIO/PathUtils.cs
@@ -52,7 +52,26 @@ public static class PathUtils
     
     public static string GetFullPath(string path)
     {
-        return Path.GetFullPath(path).Replace('\\', '/');
+        string solutionPath = PathUtils.FindSolutionDirectory();
+        return Combine(solutionPath, path);
+        //return Path.GetFullPath(path).Replace('\\', '/');
+    }
+
+    public static string FindSolutionDirectory()
+    {
+        string projectPath = AppDomain.CurrentDomain.BaseDirectory;
+        DirectoryInfo directory = new DirectoryInfo(projectPath);
+
+        while (directory != null)
+        {
+            if (Directory.GetFiles(directory.FullName, "*.sln").Length > 0)
+            {
+                return directory.FullName.Replace('\\', '/');
+            }
+            directory = directory.Parent;
+        }
+
+        return null;
     }
 
     public static string GetAbsolutePath(string baseDirectory, string relativePath)

--- a/lib-io/libIO/PathUtils.cs
+++ b/lib-io/libIO/PathUtils.cs
@@ -54,7 +54,6 @@ public static class PathUtils
     {
         string solutionPath = PathUtils.FindSolutionDirectory();
         return Combine(solutionPath, path);
-        //return Path.GetFullPath(path).Replace('\\', '/');
     }
 
     public static string FindSolutionDirectory()


### PR DESCRIPTION
Ticket: https://kcg.youtrack.cloud/issue/KCGML-2866/kcg-data-scraper-csharp-Fix-GetFilePath-returning-incorrect-path-in-Windows-after-build.props-change

Description: This PR fixes an issue where GetFilePath returns an incorrect path in Windows due to build.props modifying the output directory. The function was resolving paths relative to the build output directory instead of the solution root, causing issues when accessing configuration files.

- Modified GetFilePath to dynamically locate the solution directory instead of assuming a static path.
- Implemented FindSolutionDirectory() to traverse upwards until a .sln file is found.
